### PR TITLE
hotfix(course): http method rollback

### DIFF
--- a/src/main/java/com/lxp/content/course/infra/web/internal/CourseInternalController.java
+++ b/src/main/java/com/lxp/content/course/infra/web/internal/CourseInternalController.java
@@ -39,7 +39,7 @@ public class CourseInternalController {
     }
 
 
-    @GetMapping("/filter")
+    @PostMapping("/filter")
     public ResponseEntity<List<CourseView>> filter(
             @RequestBody @Valid CourseFilterRequest request) { // RequestBody로 변경
 


### PR DESCRIPTION
다시 post 로 바꾼 이유는 enrollment 서비스에서 get 으로 보내더라도 다시 post 로 바뀌어 전송되면서 method not allowed 예외가 발생했기 때문임